### PR TITLE
Fix indentation for some forms.

### DIFF
--- a/newlisp-mode.el
+++ b/newlisp-mode.el
@@ -516,6 +516,9 @@ This function is not available on Win32."
 (defindent dostring 1)
 (defindent doargs 1)
 (defindent dotree 1)
+(defindent do-while 1)
+(defindent do-until 1)
+(defindent if 0)
 
 ;; (defun newlisp-indent-function (indent-point state)
 ;;   ...


### PR DESCRIPTION
- `do-while` should indent the same as `while`.  The same goes for `do-until`.
- `if` should _not_ indent as in Emacs Lisp, i.e. it should not do this:
  
  ```
  (if test
      then
    else)
  ```
  
  It now does the following:
  
  ```
  (if test
      then
      else)
  ```
  
  or, more generally,
  
  ```
  (if test
      then
      test-2
      then-2
      ...
      otherwise)
  ```
  
  which agrees with the `cond`-y nature of newLISP's `if`. (On this, see http://www.newlispfanclub.alh.net/forum/viewtopic.php?f=15&t=4383.)
