### PR TITLE
Version 0.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: emacs-lisp
+sudo: false
+addons:
+  apt:
+    sources:
+      - cassou-emacs
+    packages:
+      - emacs24
+script:
+  - emacs --version
+  - emacs -batch -f batch-byte-compile newlisp-mode.el

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ newlisp-mode
 ============
 
 [![MELPA](http://melpa.org/packages/newlisp-mode-badge.svg)](http://melpa.org/#/newlisp-mode)
+[![Build Status](https://travis-ci.org/kosh04/newlisp-mode.svg?branch=master)](https://travis-ci.org/kosh04/newlisp-mode)
 
 This is a newLISP editing mode for Emacs.
 

--- a/newlisp-mode.el
+++ b/newlisp-mode.el
@@ -1,9 +1,9 @@
 ;;; newlisp-mode.el --- newLISP editing mode for Emacs
 
-;; Copyright (C) 2008-2014 KOBAYASHI Shigeru
+;; Copyright (C) 2008-2016 KOBAYASHI Shigeru (kosh)
 
 ;; Author: KOBAYASHI Shigeru <shigeru.kb[at]gmail.com>
-;; Version: 0.3.3-beta
+;; Version: 0.3.3
 ;; Created: 2008-12-15
 ;; Keywords: language,lisp,newlisp
 ;; URL: https://github.com/kosh04/newlisp-mode
@@ -43,7 +43,7 @@
 
 ;;; ChangeLog:
 
-;; version 0.3.3 (beta)
+;; version 0.3.3
 ;; - newlisp-eval: `M-:' yield up the default keymap
 ;; - implement `completion-at-point' substitute for `newlisp-complete-symbol'
 ;;
@@ -461,7 +461,7 @@ You can specify a script additional ARGS, if called with a prefix arg."
             newlisp-obarray))))
 
 (define-obsolete-function-alias 'newlisp-complete-symbol
-  #'completion-at-point "2016-02-21")
+  #'completion-at-point "0.3.3")
 
 (defun newlisp-mode-setup ()
   (setq newlisp-process-coding-system

--- a/newlisp-mode.el
+++ b/newlisp-mode.el
@@ -386,7 +386,7 @@ You can specify a script additional ARGS, if called with a prefix arg."
 (defvar newlisp-mode-map
   (let ((map (make-sparse-keymap "newlisp")))
     (set-keymap-parent map lisp-mode-shared-map)
-    (define-key map (kbd "M-:") 'newlisp-eval)
+    (define-key map (kbd "C-c M-:") 'newlisp-eval)
     (define-key map (kbd "M-C-x") 'newlisp-eval-defun)
     (define-key map (kbd "C-x C-e") 'newlisp-eval-last-sexp)
     (define-key map (kbd "C-c C-b") 'newlisp-eval-buffer)


### PR DESCRIPTION
- `newlisp-eval` now bind <kbd>C-c M-:</kbd> (<kbd>M-:</kbd> yield up the default keymap #6)
- implement `completion-at-point` substitute for `newlisp-complete-symbol`
  - It is also available with company-mode #7 